### PR TITLE
Update ScienceDefs.cfg

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/ExpPack/SciencePack/Patches/ScienceDefs.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/ExpPack/SciencePack/Patches/ScienceDefs.cfg
@@ -247,10 +247,10 @@ EXPERIMENT_DEFINITION
         SunInSpaceHigh = ..... ----. The signal is clearer here, away from all the planetary background noise.
         SunInSpaceLow = -.. .  -.- .. --... .-.. --. -.
         EveInSpace = -.-. --.- -..  -.-. --.- -.. Can't anyone help you here???
-        JoolInSpace= ....- ..--- Certainly these signals must hold the answers to life, the universe, something???
+        JoolInSpace = ....- ..--- Certainly these signals must hold the answers to life, the universe, something???
         DunaInSpace = .--. --- - .- - --- ... You've spent too much time on this project, you even see patterns on the planetary surface
         LaytheInSpace =  - --- .-- . .-.. You have a niggling feeling you forgot something.
-    
+    }
 }
 
 EXPERIMENT_DEFINITION


### PR DESCRIPTION
Insert missing end bracket for RESULTS in USI_RadioScience.

Insert space for consistency in Results line containing JoolInSpace.

----
Sorry, still learning how to do PR's.  Not sure why line 274 got changed to remove and re-add.  I didn't do that.  I only inserted the } and the space.  Github appears to have added that for some reason.